### PR TITLE
GraphQL(Docs): Clarification for queries allowed in rules.

### DIFF
--- a/src/pages/authorization/directive.mdx
+++ b/src/pages/authorization/directive.mdx
@@ -34,6 +34,8 @@ Here we define a type `Todo`, that's got an `id`, the `text` of the todo and the
 
 The `query` rule in this case expects the JWT to contain a claim `"USER": "..."` giving the username of the logged in user, and says: you can query any todo that has your username as the owner.
 
+In this example we use the `queryTodo` query that will be auto generated after uploading this schema. When using a query in a rule, you can only use the `queryTypeName` query. Where `TypeName` matches the name of where the `@auth` directive is attached. In other words, we could not have used the `getTodo` query in our rule above to query by id only.
+
 This rule is applied automatically at query time.  For example, the query
 
 ```graphql


### PR DESCRIPTION
This will add clarification for the user and prevent users from getting the error message: 

> "resolving updateGQLSchema failed because Type User: @auth: expected only queryTypeName rules,but found getTypeName"

FYI: the template for pull request is missing here like it is on the dgraph repository. I think this naming convention is correct.