### PR TITLE
docs(GraphQL): Fixed type name error

### DIFF
--- a/src/pages/custom/field.mdx
+++ b/src/pages/custom/field.mdx
@@ -50,7 +50,7 @@ type User {
     username: String! @id 
 
     # join local data with remote
-    gitDetails: User @custom(http: {
+    gitDetails: GitHubUser @custom(http: {
         url:  "https://api.github.com/graphql",
         method: POST,
         graphql: "query(username: String!) { user(login: $username) }",


### PR DESCRIPTION
Pretty self explanatory. I believe it was just a naming error as it made no sense to point to itself instead of the @remote type.