### PR TITLE
docs(GraphQL): Add links to other doc pages

### DIFF
--- a/src/pages/doc/custom/mutation.mdx
+++ b/src/pages/doc/custom/mutation.mdx
@@ -38,6 +38,11 @@ type Mutation {
 }
 ```
 
-(Note: there's more docs coming about turning off the generated mutations, protecting them with authorization rules etc.)
+## Learn more
+
+Find out more about how to turn off generated mutations and protecting mutations with authorization rules at:
+
+* [Remote Types - Turning off Generated Mutations with `@remote` Directive](/doc/custom/directive)
+* [Securing Mutations with the `@auth` Directive](/doc/authorization/mutations)
 
 ---


### PR DESCRIPTION
These doc pages are mentioned as coming soon when they already exist and should simply be linked to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/graphql-dgraph-web/27)
<!-- Reviewable:end -->
