### PR TITLE
fix: change authorization header to small letter in docs

### DIFF
--- a/src/pages/slash-graphql/advanced-queries.mdx
+++ b/src/pages/slash-graphql/advanced-queries.mdx
@@ -59,6 +59,16 @@ curl -H "Content-Type: application/graphql+-" -H "x-auth-token: <api-key>" -XPOS
 
 ### gRPC
 
+You need to run the scripts inside a docker container, use the code provided below:
+```docker
+FROM python:3.8
+RUN pip install pydgraph
+RUN pip install grpcio==1.19.0
+WORKDIR /app
+```
+
+Build it using `docker build . -t grpc-client`, and then run it using `docker run -it -v $PWD:/app grpc-client bash` from the folder that contains your test script. 
+
 The gRPC endpoint works identically to Dgraph's gRPC endpoint, with the additional constraint of requiring authentication on every gRPC call. The Slash API token must be passed in the "Authorization" metadata to every gRPC call. This may be achieved by using [Metadata Call Credentials](https://godoc.org/google.golang.org/grpc/credentials#PerRPCCredentials) or the equivalent in your language.
 
 For example, if your GraphQL Endpoint is `https://frozen-mango-42.eu-central-1.aws.cloud.dgraph.io/graphql`, your gRPC endpoint will be `frozen-mango-42.grpc.eu-central-1.aws.cloud.dgraph.io:443`.

--- a/src/pages/slash-graphql/advanced-queries.mdx
+++ b/src/pages/slash-graphql/advanced-queries.mdx
@@ -59,15 +59,7 @@ curl -H "Content-Type: application/graphql+-" -H "x-auth-token: <api-key>" -XPOS
 
 ### gRPC
 
-You need to run the scripts inside a docker container, use the code provided below:
-```docker
-FROM python:3.8
-RUN pip install pydgraph
-RUN pip install grpcio==1.19.0
-WORKDIR /app
-```
-
-Build it using `docker build . -t grpc-client`, and then run it using `docker run -it -v $PWD:/app grpc-client bash` from the folder that contains your test script. 
+*We are experiencing issues with `pydgraph` compatibility with the latest version of `grpcio`. If you are experiencing errors, please downgrade your grpcio package to version `1.19.0`.*
 
 The gRPC endpoint works identically to Dgraph's gRPC endpoint, with the additional constraint of requiring authentication on every gRPC call. The Slash API token must be passed in the "Authorization" metadata to every gRPC call. This may be achieved by using [Metadata Call Credentials](https://godoc.org/google.golang.org/grpc/credentials#PerRPCCredentials) or the equivalent in your language.
 

--- a/src/pages/slash-graphql/advanced-queries.mdx
+++ b/src/pages/slash-graphql/advanced-queries.mdx
@@ -83,7 +83,7 @@ GRPC_PORT = "443"
 You will then need to pass your API key as follows:
 ```python
 creds = grpc.ssl_channel_credentials()
-call_credentials = grpc.metadata_call_credentials(lambda context, callback: callback((("Authorization", "<api-key>"),), None))
+call_credentials = grpc.metadata_call_credentials(lambda context, callback: callback((("authorization", "<api-key>"),), None))
 composite_credentials = grpc.composite_channel_credentials(creds, call_credentials)
 client_stub = pydgraph.DgraphClientStub('{host}:{port}'.format(host=GRPC_HOST, port=GRPC_PORT), composite_credentials)
 client = pydgraph.DgraphClient(client_stub)


### PR DESCRIPTION
gRPC requests were failing when the header was set to capital letter. This fix will change the documentation to use small letter for example script but it will not fix the error on capital letter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/graphql-dgraph-web/46)
<!-- Reviewable:end -->
